### PR TITLE
Support Grafana Benutzername und Passwort mit mehr als 5 Zeichen

### DIFF
--- a/MQTTDevice2.ino
+++ b/MQTTDevice2.ino
@@ -197,8 +197,8 @@ InfluxDBClient dbClient;
 bool startDB = false;
 bool startVis = false;
 char dbServer[28] = "http://192.168.100.30:8086"; // InfluxDB Server IP
-char dbUser[5] = "";
-char dbPass[5] = "";
+char dbUser[15] = "";
+char dbPass[15] = "";
 char dbDatabase[11] = "mqttdevice";
 char dbVisTag[15] = "";
 unsigned long upInflux = 15000;


### PR DESCRIPTION
Aktuell werden für Benutzername und Passwort für Grafana nur 5 Zeichen unterstützt:

https://github.com/InnuendoPi/MQTTDevice2/blob/71691893febb536204df3cf44b17c334738e9281/MQTTDevice2.ino#L200-L201

Dies ist mitunter nicht ausreichend. Daher habe ich es wieder auf 15 erhöht.